### PR TITLE
fix: prevent null dereference, error swallowing, [1m[1m[35mand[0m…

### DIFF
--- a/app/(dashboard)/favorites/components/sorty-by.tsx
+++ b/app/(dashboard)/favorites/components/sorty-by.tsx
@@ -32,12 +32,13 @@ export function SortBy({ favorites, onSortChange }: SortByProps) {
     }
     return 0;
   }
-  favorites.forEach((fav) => {
-    fav.distance = calcDistance(fav.coordinates);
-  });
+  const favoritesWithDistance = favorites.map((fav) => ({
+    ...fav,
+    distance: calcDistance(fav.coordinates),
+  }));
 
   function handleSortChange(value: string) {
-    const sortedFavorites = [...favorites];
+    const sortedFavorites = [...favoritesWithDistance];
     const distanceCmp = (a: FavStationType, b: FavStationType) =>
       (a.distance || 0) - (b.distance || 0);
     switch (value) {

--- a/app/(dashboard)/favorites/lib/favorites.ts
+++ b/app/(dashboard)/favorites/lib/favorites.ts
@@ -70,9 +70,7 @@ export async function removeFromFavorites(stationId: string) {
     }
   } catch (err) {
     console.error(err);
-  } finally {
-    console.log('removed');
-    return await new Promise((resolve) => setTimeout(resolve, 5));
+    throw err;
   }
 }
 
@@ -106,8 +104,7 @@ export async function formToFavorites(name: string, stationId: string) {
     }
   } catch (err) {
     console.error(err);
-  } finally {
-    return await new Promise((resolve) => setTimeout(resolve, 5));
+    throw err;
   }
 }
 
@@ -131,9 +128,7 @@ export async function resetFavoriteName(stationId: string) {
     }
   } catch (err) {
     console.error(err);
-  } finally {
-    console.log('removed');
-    return await new Promise((resolve) => setTimeout(resolve, 5));
+    throw err;
   }
 }
 

--- a/app/(dashboard)/settings/lib/save-settings.ts
+++ b/app/(dashboard)/settings/lib/save-settings.ts
@@ -22,5 +22,5 @@ export async function loadSettings() {
     .select(['mapsToUse'])
     .filter('id', sessId)
     .getMany();
-  return data[0]['mapsToUse'];
+  return data[0]?.['mapsToUse'] ?? null;
 }


### PR DESCRIPTION
## Summary

- **`loadSettings` null dereference** — `data[0]['mapsToUse']` would throw if the user had no settings record; now uses optional chaining with a `null` fallback.
- **`finally` blocks swallowing errors** — `removeFromFavorites`, `formToFavorites`, and `resetFavoriteName` all returned from `finally`, which silently discarded any thrown exception. Replaced with `throw err` in `catch` so callers see failures.
- **Prop mutation in `SortBy`** — `favorites.forEach(fav => fav.distance = ...)` mutated the original objects passed from the parent on every render. Now uses `.map()` with a spread copy so parent state is never touched.

## Test plan

- [ ] Add a favorite station, then sort by distance and by date — verify list reorders correctly
- [ ] Remove a favorite while network is degraded — verify the error surfaces to the UI rather than silently passing
- [ ] Log in with a user that has no saved settings — verify the app loads without crashing